### PR TITLE
Whitelist files to include when publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "json",
     "manifest"
   ],
+  "files": [
+    "/index.js"
+  ],
   "scripts": {
     "test": "node tests/runner.js && ./node_modules/.bin/eslint index.js tests/**/*.js",
     "lint": "eslint ."


### PR DESCRIPTION
## Build

#### Whitelist files to include when publishing (#45)

To reduce the final bundle size.

**Before**

```
➜ npm publish --dry-run

npm notice === Tarball Contents ===
npm notice 368B  .editorconfig
npm notice 280B  .ember-cli
npm notice 240B  .eslintignore
npm notice 37B   .watchmanconfig
npm notice 43B   .github/CODEOWNERS
npm notice 72B   .eslintrc.js
npm notice 154B  tests/.eslintrc.js
npm notice 156B  tests/helpers/assert.js
npm notice 1.6kB tests/unit/configure-hook-test.js
npm notice 3.5kB index.js
npm notice 556B  tests/unit/plugin-test.js
npm notice 400B  tests/runner.js
npm notice 1.3kB package.json
npm notice 1.1kB LICENSE.md
npm notice 5.1kB README.md
npm notice 176B  .travis.yml
npm notice 375B  .github/workflows/contributors.yml
npm notice 691B  .github/dependabot.yml
npm notice === Tarball Details ===
npm notice name:          ember-cli-deploy-index-json
npm notice version:       1.0.0
npm notice package size:  6.2 kB
npm notice unpacked size: 16.1 kB
npm notice total files:   18
```

**After**

```
➜ npm publish --dry-run

npm notice === Tarball Contents ===
npm notice 3.5kB index.js
npm notice 1.3kB package.json
npm notice 1.1kB LICENSE.md
npm notice 5.1kB README.md
npm notice === Tarball Details ===
npm notice name:          ember-cli-deploy-index-json
npm notice version:       1.0.0
npm notice package size:  4.1 kB
npm notice unpacked size: 11.0 kB
npm notice total files:   4
```
